### PR TITLE
fix: replace continuous streaming with event-driven frame capture

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,9 +43,7 @@ function startPythonBackend() {
 ipcMain.on('to-python', (_, message) => {
   if (pythonProcess) {
     pythonProcess.stdin.write(`${message}\n`);
-    pythonProcess.stdout.once('data', (data: Buffer) => {
-      console.log(`One-Time Python Output: ${data.toString()}`);
-    });
+    // Don't wait for output as assistant.answer will handle response
   } else {
     console.error('Python process is not running.');
   }

--- a/src/components/PromptForm.vue
+++ b/src/components/PromptForm.vue
@@ -6,7 +6,7 @@
       <p>Antwort von Python: {{ response }}</p>
     </div>
   </template>
-  
+
   <script>
   export default {
     data() {
@@ -17,7 +17,7 @@
     },
     methods: {
       sendMessage() {
-        window.electronAPI.sendToPython(this.message);
+        window.electronAPI.sendToPython(`TEXT_INPUT:${this.message}`);
       },
     },
     mounted() {


### PR DESCRIPTION
Fix continuous frame streaming issue by implementing event-driven frame capture.

Changes:
- Remove continuous frame streaming loop
- Add event-based frame capture for text input
- Optimize frame capture in speech recognition
- Add frame rate limiting for webcam stream

Frame capture now only occurs when:
1. User speaks (via speech recognition)
2. User types text in frontend

Testing:
- Verified frame capture only occurs on user input
- Checked proper frame synchronization with input
- Confirmed no continuous streaming to LLM

Link to Devin run: https://app.devin.ai/sessions/45e324cd500c48858cc4ea701cceb91c
